### PR TITLE
Added views for non existent entries

### DIFF
--- a/lattedb/project/formfac/rest/serializers.py
+++ b/lattedb/project/formfac/rest/serializers.py
@@ -7,6 +7,8 @@ server.
 """
 from rest_framework import routers, serializers, viewsets
 
+from django.db.models import Q
+
 from lattedb.project.formfac.models import ConcatenatedFormFactor4DFile
 from lattedb.project.formfac.models import DiskConcatenatedFormFactor4DFile
 from lattedb.project.formfac.models import TapeConcatenatedFormFactor4DFile
@@ -36,6 +38,11 @@ from lattedb.project.formfac.models import Spectrum4DFile
 from lattedb.project.formfac.models import DiskSpectrum4DFile
 
 VIEWSETS = []
+
+
+Q_ON_TAPE_FALSE = Q(tape__isnull=True) | (Q(tape__isnull=False) & Q(tape__exists=False))
+Q_ON_DISK_FALSE = Q(disk__isnull=True) | (Q(disk__isnull=False) & Q(disk__exists=False))
+Q_DOES_NOT_EXIST = Q_ON_DISK_FALSE & Q_ON_TAPE_FALSE
 
 # -------------------------------------
 # ConcatenatedFormFactor4D
@@ -128,6 +135,16 @@ class TapeTSlicedSAveragedFormFactor4DFileViewSet(viewsets.ReadOnlyModelViewSet)
 
 
 VIEWSETS.append(TapeTSlicedSAveragedFormFactor4DFileViewSet)
+
+
+class NonExistentSlicedSAveragedFormFactor4DFileViewSet(viewsets.ReadOnlyModelViewSet):
+    name = "non-existent-sliced-averaged-formfactor"
+    exclude_from_nav = True
+    queryset = TSlicedSAveragedFormFactor4DFile.objects.filter(Q_DOES_NOT_EXIST)
+    serializer_class = TSlicedSAveragedFormFactor4DFileSerializer
+
+
+VIEWSETS.append(NonExistentSlicedSAveragedFormFactor4DFileViewSet)
 
 # -------------------------------------
 # TSlicedFormFactor4D
@@ -231,6 +248,17 @@ class TapeCorrelatorH5DsetFileViewSet(viewsets.ReadOnlyModelViewSet):
 
 VIEWSETS.append(TapeCorrelatorH5DsetFileViewSet)
 
+
+class NonExistentCorrelatorH5DsetFileViewSet(viewsets.ReadOnlyModelViewSet):
+    name = "non-existent-correlator-h5dset"
+    exclude_from_nav = True
+    queryset = CorrelatorMeta.objects.filter(Q_DOES_NOT_EXIST)
+    serializer_class = CorrelatorMetaSerializer
+
+
+VIEWSETS.append(NonExistentCorrelatorH5DsetFileViewSet)
+
+
 # -------------------------------------
 # Spectrum
 # -------------------------------------
@@ -277,6 +305,16 @@ class TapeTSlicedSAveragedSpectrum4DFileViewSet(viewsets.ReadOnlyModelViewSet):
 
 VIEWSETS.append(TapeTSlicedSAveragedSpectrum4DFileViewSet)
 
+
+class NonExistentSlicedSAveragedSpectrum4DFileViewSet(viewsets.ReadOnlyModelViewSet):
+    name = "non-existent-sliced-averaged-spectrum"
+    exclude_from_nav = True
+    queryset = TSlicedSAveragedSpectrum4DFile.objects.filter(Q_DOES_NOT_EXIST)
+    serializer_class = TSlicedSAveragedSpectrum4DFileSerializer
+
+
+VIEWSETS.append(NonExistentSlicedSAveragedSpectrum4DFileViewSet)
+
 # -------------------------------------
 # TSlicedSpectrum4D
 # -------------------------------------
@@ -304,6 +342,16 @@ class DiskTSlicedSpectrum4DFileViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 VIEWSETS.append(DiskTSlicedSpectrum4DFileViewSet)
+
+
+class NonExistentSlicedSpectrum4DFileViewSet(viewsets.ReadOnlyModelViewSet):
+    name = "non-existent-sliced-spectrum"
+    exclude_from_nav = True
+    queryset = TSlicedSpectrum4DFile.objects.filter(Q_ON_DISK_FALSE)
+    serializer_class = TSlicedSpectrum4DFileSerializer
+
+
+VIEWSETS.append(NonExistentSlicedSpectrum4DFileViewSet)
 
 # -------------------------------------
 # TSlicedSAveragedSpectrum4D

--- a/lattedb/project/formfac/templates/table.html
+++ b/lattedb/project/formfac/templates/table.html
@@ -14,8 +14,8 @@
 
 {% block content %}
 <div class="jumbotron">
-    <h1>{{model.verbose_name}}</h1>
-    {% if model %}<p>{{model.get_doc}}</p>{% endif %}
+    <h1>{{title}}</h1>
+    {% if subtitle %}<p>{{subtitle}}</p>{% endif %}
 </div>
 <div class="w-100 px-5">
     {% if status.total > 0 %}

--- a/lattedb/project/formfac/urls.py
+++ b/lattedb/project/formfac/urls.py
@@ -23,14 +23,29 @@ from lattedb.project.formfac.views import DiskTSlicedSAveragedFormFactor4DStatus
 from lattedb.project.formfac.views import TapeTSlicedSAveragedFormFactor4DStatusView
 from lattedb.project.formfac.views import DiskTSlicedFormFactor4DStatusView
 from lattedb.project.formfac.views import DiskFormFactor4DStatusView
+from lattedb.project.formfac.views import NonExistentSlicedSAveragedFormFactor4DView
 
 from lattedb.project.formfac.views import DiskCorrelatorH5DsetStatusView
 from lattedb.project.formfac.views import TapeCorrelatorH5DsetStatusView
+from lattedb.project.formfac.views import NonExistentCorrelatorH5DsetView
+
+
+# from lattedb.project.formfac.views import NonExistentCorrelatorH5DsetFileViewSet
+
 
 from lattedb.project.formfac.views import DiskTSlicedSAveragedSpectrum4DStatusView
 from lattedb.project.formfac.views import TapeTSlicedSAveragedSpectrum4DStatusView
 from lattedb.project.formfac.views import DiskTSlicedSpectrum4DStatusView
 from lattedb.project.formfac.views import DiskSpectrum4DStatusView
+from lattedb.project.formfac.views import NonExistentSlicedSAveragedSpectrum4DView
+from lattedb.project.formfac.views import NonExistentSlicedSpectrum4DView
+
+
+# from lattedb.project.formfac.views import (
+#    NonExistentSlicedSAveragedSpectrum4DFileViewSet,
+# )
+# from lattedb.project.formfac.views import NonExistentSlicedSpectrum4DFileViewSet
+
 
 from lattedb.project.formfac.rest.serializers import ROUTER
 
@@ -58,12 +73,22 @@ urlpatterns = [
         name="Sliced Averaged Form Factor Tape Status",
     ),
     path(
+        "non-existent-sliced-averaged-status",
+        NonExistentSlicedSAveragedFormFactor4DView.as_view(),
+        name="Non Existent Sliced Averaged Form Factor Status",
+    ),
+    path(
         "disk-sliced-status",
         DiskTSlicedFormFactor4DStatusView.as_view(),
         name="Sliced Form Factor Disk Status",
     ),
     path(
         "disk-status",
+        DiskFormFactor4DStatusView.as_view(),
+        name="Form Factor Disk Status",
+    ),
+    path(
+        "non-existent-disk-status",
         DiskFormFactor4DStatusView.as_view(),
         name="Form Factor Disk Status",
     ),
@@ -76,6 +101,11 @@ urlpatterns = [
         "tape-corr-status",
         TapeCorrelatorH5DsetStatusView.as_view(),
         name="Correlator Tape Status",
+    ),
+    path(
+        "non-existent-correlator",
+        NonExistentCorrelatorH5DsetView.as_view(),
+        name="Non Existent Correlator Status",
     ),
     path(
         "disk-spec-sliced-averaged-status",
@@ -96,5 +126,15 @@ urlpatterns = [
         "disk-spec-status",
         DiskSpectrum4DStatusView.as_view(),
         name="Spectrum Disk Status",
+    ),
+    path(
+        "non-existent-sliced-averaged-spectrum",
+        NonExistentSlicedSAveragedSpectrum4DView.as_view(),
+        name="Non Existent Sliced Averaged Spectrum Status",
+    ),
+    path(
+        "non-existent-sliced-spectrum",
+        NonExistentSlicedSpectrum4DView.as_view(),
+        name="Non Existent Sliced Spectrum Status",
     ),
 ]

--- a/lattedb/templates/base.html
+++ b/lattedb/templates/base.html
@@ -30,6 +30,12 @@
                         <li><a class="dropdown-item" href="{% url 'Project formfac:Concatenated Form Factor Tape Status' %}">Concatenated</a></li>
                     </ul>
                 </li>
+                <li class="dropdown-submenu">
+                    <a class="dropdown-item dropdown-toggle" href="#">Non-existent</a>
+                    <ul class="dropdown-menu">
+                        <li><a class="dropdown-item" href="{% url 'Project formfac:Non Existent Sliced Averaged Form Factor Status' %}">T-sliced & source averaged</a></li>
+                    </ul>
+                </li>
             </ul>
         </li>
         <li class="dropdown-submenu">
@@ -45,6 +51,12 @@
                     <a class="dropdown-item dropdown-toggle" href="#">Tape</a>
                     <ul class="dropdown-menu">
                         <li><a class="dropdown-item" href="{% url 'Project formfac:Correlator Tape Status' %}">Raw</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-submenu">
+                    <a class="dropdown-item dropdown-toggle" href="#">Non-existent</a>
+                    <ul class="dropdown-menu">
+                        <li><a class="dropdown-item" href="{% url 'Project formfac:Non Existent Correlator Status' %}">Raw</a></li>
                     </ul>
                 </li>
             </ul>
@@ -64,6 +76,13 @@
                     <a class="dropdown-item dropdown-toggle" href="#">Tape</a>
                     <ul class="dropdown-menu">
                         <li><a class="dropdown-item" href="{% url 'Project formfac:Sliced Averaged Spectrum Tape Status' %}">T-sliced & source averaged</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-submenu">
+                    <a class="dropdown-item dropdown-toggle" href="#">Non-existent</a>
+                    <ul class="dropdown-menu">
+                        <li><a class="dropdown-item" href="{% url 'Project formfac:Non Existent Sliced Averaged Spectrum Status' %}">T-sliced & source averaged</a></li>
+                        <li><a class="dropdown-item" href="{% url 'Project formfac:Non Existent Sliced Spectrum Status' %}">T-sliced</a></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
This PR builds a new `non-existent` category for status views which presents entries which are neither on tape nor disk. 

![Screen Shot 2020-05-19 at 11 43 47](https://user-images.githubusercontent.com/35035055/82311499-1437d880-99c6-11ea-8d32-a5a10615763c.png)


It builds on top of PR #67 (which should be merged first). Similarly, it should be tested locally (does it meet requirements) before deploying on ithems.

If accepted, this PR closes #64.
