### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             max-parallel: 4
             matrix:
-                python-version: [3.6, 3.7]
+                python-version: [3.7]
                 platform: [ubuntu-latest, macos-latest]
         runs-on: ${{ matrix.platform }}
         steps:
@@ -37,6 +37,9 @@ jobs:
 
             - name: Install lattedb
               run: pip install -e .
+
+            - name: Migrate tables
+              run: lattedb migrate
 
             - name: Run test
               run: pytest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,9 @@ jobs:
             - name: Upgrade pip
               run: python -m pip install --upgrade pip
 
+            - name: Remove psycopg2 from requirements (fails on MacOS install)
+              run: awk '!/psycopg2/' requirements.txt  > temp.txt && mv temp.txt requirements.txt
+
             - name: Install dependencies
               run: |
                   pip install -r requirements.txt

--- a/lattedb/current/tests.py
+++ b/lattedb/current/tests.py
@@ -16,6 +16,9 @@ class LocalParser(ObjectParser):
         "diracstruct": "gamma_5",
         "momentum": "0",
         "description": "pseudoscalar",
+        "nx": 1,
+        "ny": 2,
+        "nz": 3,
     }
 
 

--- a/lattedb/wavefunction/tests.py
+++ b/lattedb/wavefunction/tests.py
@@ -51,6 +51,9 @@ class HadronParser(ObjectParser):
         "isospin_x2": "1",
         "isospin_z_x2": "1",
         "momentum": "0",
+        "nx": 1,
+        "ny": 2,
+        "nz": 3,
     }
 
     _consistency_check_changes = [
@@ -80,6 +83,9 @@ class MesonParser(ObjectParser):
         "isospin_x2": "1",
         "isospin_z_x2": "1",
         "momentum": "0",
+        "nx": 1,
+        "ny": 2,
+        "nz": 3,
     }
 
 

--- a/settings-example.yaml
+++ b/settings-example.yaml
@@ -18,4 +18,5 @@ ALLOWED_HOSTS:
     - 127.0.0.1
     - localhost
     - ithems.lbl.gov
+    - testserver
 DEBUG: True


### PR DESCRIPTION
This PR repairs unit tests.

It adds a migrate before running automated tests and added missing `nx`, `ny` and `nz` arguments to hadrons, mesons and currents.