### PR TITLE
Added action to deploy image to spin registry

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - master
+
+
+steps:
+  - name: Checkout code
+    uses: actions/checkout@v2
+
+  - name: Build and push Docker images
+    uses: docker/build-push-action@v1
+    with:
+      username: ${{ secrets.SPIN_USERNAME }}
+      password: ${{ secrets.SPIN_TOKEN }}
+      repository: registry.spin.nersc.gov/lattedb/lattedb
+      tags: latest

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -3,15 +3,16 @@ on:
     branches:
       - master
 
+jobs:
+    deploy-image:
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v2
 
-steps:
-  - name: Checkout code
-    uses: actions/checkout@v2
-
-  - name: Build and push Docker images
-    uses: docker/build-push-action@v1
-    with:
-      username: ${{ secrets.SPIN_USERNAME }}
-      password: ${{ secrets.SPIN_TOKEN }}
-      repository: registry.spin.nersc.gov/lattedb/lattedb
-      tags: latest
+          - name: Build and push Docker images
+            uses: docker/build-push-action@v1
+            with:
+              username: ${{ secrets.SPIN_USERNAME }}
+              password: ${{ secrets.SPIN_TOKEN }}
+              repository: registry.spin.nersc.gov/lattedb/lattedb
+              tags: latest


### PR DESCRIPTION
This workflow automatically builds and deploys the docker image to the spin registry system.
Thus far, it does not update the web-app. This requires triggering a new build process in the rancher-spin system.